### PR TITLE
Add authentication and tide heights endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 WORLDTIDES_KEY=your_worldtides_api_key
 OPENWEATHER_KEY=your_openweather_api_key
+BASIC_AUTH_USER=your_username
+BASIC_AUTH_PASS=your_password
+MCP_API_KEY=your_api_key

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ python extract_gate_times.py
 
 - `/tides` and `/tides/{YYYY-MM-DD}` - 12\u00a0months of cached tide data from
   [WorldTides](https://www.worldtides.info/apidocs) converted to local time.
+- `/tide-heights` - half hour tide heights for the next 7 days refreshed once a
+  week.
 - `/weather/{YYYY-MM-DD}` - weather forecast for a day if it is within the next
   five days using [OpenWeather](https://openweathermap.org/api/one-call-3), also
   returned in local time.
@@ -30,8 +32,12 @@ Tide, weather and gate time data are cached in memory and refreshed every
 format for Conwy, North Wales.
 
 
-Copy `.env.example` to `.env` and fill in your `WORLDTIDES_KEY` and
-`OPENWEATHER_KEY`.
+Copy `.env.example` to `.env` and fill in your `WORLDTIDES_KEY`,
+`OPENWEATHER_KEY`, and authentication values `BASIC_AUTH_USER`,
+`BASIC_AUTH_PASS` or `MCP_API_KEY`.
+
+All API endpoints require authentication using either HTTP Basic credentials or
+an `X-API-KEY` header containing the value of `MCP_API_KEY`.
 
 ## Using a virtual environment
 

--- a/mcp_api.py
+++ b/mcp_api.py
@@ -3,14 +3,21 @@ from zoneinfo import ZoneInfo
 import os
 import csv
 import asyncio
+import secrets
 import requests
-from fastapi import FastAPI, HTTPException
+from typing import List, Optional
+from fastapi import FastAPI, HTTPException, Depends, Security
+from fastapi.security import HTTPBasic, HTTPBasicCredentials, APIKeyHeader
+from pydantic import BaseModel
 from dotenv import load_dotenv
 
 load_dotenv()
 
 WORLDTIDES_KEY = os.getenv("WORLDTIDES_KEY")
 OPENWEATHER_KEY = os.getenv("OPENWEATHER_KEY")
+BASIC_AUTH_USER = os.getenv("BASIC_AUTH_USER")
+BASIC_AUTH_PASS = os.getenv("BASIC_AUTH_PASS")
+MCP_API_KEY = os.getenv("MCP_API_KEY")
 LAT = 53.28
 LON = -3.83
 TZ = ZoneInfo("Europe/London")
@@ -21,6 +28,112 @@ app = FastAPI()
 app.state.tide_cache = []
 app.state.weather_cache = {}
 app.state.gate_times = {}
+app.state.tide_heights_cache = []
+app.state.tide_heights_last_load = datetime.min
+
+security_basic = HTTPBasic(auto_error=False)
+api_key_header = APIKeyHeader(name="X-API-KEY", auto_error=False)
+
+
+def verify_auth(
+    credentials: Optional[HTTPBasicCredentials] = Depends(security_basic),
+    api_key: Optional[str] = Security(api_key_header),
+):
+    if MCP_API_KEY and api_key and secrets.compare_digest(api_key, MCP_API_KEY):
+        return
+    if (
+        credentials
+        and BASIC_AUTH_USER
+        and BASIC_AUTH_PASS
+        and secrets.compare_digest(credentials.username, BASIC_AUTH_USER)
+        and secrets.compare_digest(credentials.password, BASIC_AUTH_PASS)
+    ):
+        return
+    raise HTTPException(
+        status_code=401, detail="Unauthorized", headers={"WWW-Authenticate": "Basic"}
+    )
+
+
+def beaufort(speed: float) -> int:
+    """Convert meters/second wind speed to Beaufort scale."""
+    thresholds = [
+        0.5,
+        1.5,
+        3.3,
+        5.5,
+        7.9,
+        10.7,
+        13.8,
+        17.1,
+        20.7,
+        24.4,
+        28.4,
+        32.6,
+    ]
+    for i, t in enumerate(thresholds):
+        if speed < t:
+            return i
+    return 12
+
+
+class Temp(BaseModel):
+    day: float
+    min: float
+    max: float
+    night: float
+    eve: float
+    morn: float
+
+
+class FeelsLike(BaseModel):
+    day: float
+    night: float
+    eve: float
+    morn: float
+
+
+class WeatherDesc(BaseModel):
+    id: int
+    main: str
+    description: str
+    icon: str
+
+
+class WeatherDay(BaseModel):
+    dt: str
+    sunrise: Optional[str] = None
+    sunset: Optional[str] = None
+    moonrise: Optional[str] = None
+    moonset: Optional[str] = None
+    moon_phase: Optional[float] = None
+    summary: Optional[str] = None
+    temp: Temp
+    feels_like: FeelsLike
+    pressure: int
+    humidity: int
+    dew_point: float
+    wind_speed: float
+    wind_speed_beaufort: int
+    wind_gust: Optional[float] = None
+    wind_gust_beaufort: Optional[int] = None
+    wind_deg: int
+    weather: List[WeatherDesc]
+    clouds: int
+    pop: float
+    uvi: float
+
+
+class TideEvent(BaseModel):
+    dt: str
+    date: str
+    height: float
+    type: str
+
+
+class TideHeight(BaseModel):
+    dt: str
+    date: str
+    height: float
 
 
 def fetch_tide_chunk(start_date: datetime, days: int):
@@ -70,6 +183,37 @@ def load_tide_data():
         current += timedelta(days=chunk_days)
 
 
+def load_tide_heights():
+    if not WORLDTIDES_KEY:
+        print("WORLDTIDES_KEY not set; skipping tide heights fetch")
+        return
+
+    start = datetime.utcnow()
+    heights = fetch_tide_heights(start, 7)
+    for h in heights:
+        dt_iso = iso_local(h["dt"])
+        h["dt"] = dt_iso
+        h["date"] = dt_iso
+
+    app.state.tide_heights_cache = heights
+    app.state.tide_heights_last_load = datetime.utcnow()
+
+
+def fetch_tide_heights(start_date: datetime, days: int):
+    url = "https://www.worldtides.info/api/v3"
+    params = {
+        "heights": "",
+        "lat": LAT,
+        "lon": LON,
+        "date": start_date.strftime("%Y-%m-%d"),
+        "days": days,
+        "key": WORLDTIDES_KEY,
+    }
+    r = requests.get(url, params=params, timeout=10)
+    r.raise_for_status()
+    return r.json().get("heights", [])
+
+
 def load_weather_data():
     if not OPENWEATHER_KEY:
         print("OPENWEATHER_KEY not set; skipping weather fetch")
@@ -93,6 +237,10 @@ def load_weather_data():
         for key in ("dt", "sunrise", "sunset", "moonrise", "moonset"):
             if key in day:
                 day[key] = iso_local(day[key])
+
+        day["wind_speed_beaufort"] = beaufort(day.get("wind_speed", 0))
+        if "wind_gust" in day:
+            day["wind_gust_beaufort"] = beaufort(day["wind_gust"])
 
         app.state.weather_cache[date_str] = day
 
@@ -141,9 +289,7 @@ def load_gate_times():
             elif 0 <= hour <= 23 and 0 <= minute <= 59:
                 dt = datetime(2025, month, day, hour, minute, tzinfo=TZ)
             else:
-                print(
-                    f"Invalid time '{row['time']}' in gate times CSV; skipping"
-                )
+                print(f"Invalid time '{row['time']}' in gate times CSV; skipping")
                 continue
             key = dt.strftime("%Y-%m-%d")
             event = {"datetime": dt.isoformat(), "action": row["action"]}
@@ -156,6 +302,8 @@ async def refresh_loop():
         await asyncio.to_thread(load_tide_data)
         await asyncio.to_thread(load_weather_data)
         await asyncio.to_thread(load_gate_times)
+        if datetime.utcnow() - app.state.tide_heights_last_load > timedelta(days=7):
+            await asyncio.to_thread(load_tide_heights)
         await asyncio.sleep(60 * 60 * 12)
 
 
@@ -164,16 +312,17 @@ async def startup_event():
     await asyncio.to_thread(load_tide_data)
     await asyncio.to_thread(load_weather_data)
     await asyncio.to_thread(load_gate_times)
+    await asyncio.to_thread(load_tide_heights)
     asyncio.create_task(refresh_loop())
 
 
-@app.get("/tides")
-def all_tides():
-    return app.state.tide_cache
+@app.get("/tides", response_model=List[TideEvent])
+def all_tides(offset: int = 0, limit: int = 100, auth: None = Depends(verify_auth)):
+    return app.state.tide_cache[offset : offset + limit]
 
 
-@app.get("/tides/{date}")
-def tides_for_date(date: str):
+@app.get("/tides/{date}", response_model=List[TideEvent])
+def tides_for_date(date: str, auth: None = Depends(verify_auth)):
     try:
         target = datetime.strptime(date, "%Y-%m-%d").date()
     except ValueError:
@@ -190,8 +339,15 @@ def tides_for_date(date: str):
     return results
 
 
-@app.get("/weather/{date}")
-def weather(date: str):
+@app.get("/tide-heights", response_model=List[TideHeight])
+def tide_heights(offset: int = 0, limit: int = 100, auth: None = Depends(verify_auth)):
+    if datetime.utcnow() - app.state.tide_heights_last_load > timedelta(days=7):
+        load_tide_heights()
+    return app.state.tide_heights_cache[offset : offset + limit]
+
+
+@app.get("/weather/{date}", response_model=WeatherDay)
+def weather(date: str, auth: None = Depends(verify_auth)):
     try:
         target = datetime.strptime(date, "%Y-%m-%d").date()
     except ValueError:
@@ -209,12 +365,12 @@ def weather(date: str):
 
 
 @app.get("/gate-times")
-def gate_times_all():
+def gate_times_all(auth: None = Depends(verify_auth)):
     return app.state.gate_times
 
 
 @app.get("/gate-times/{date}")
-def gate_times_date(date: str):
+def gate_times_date(date: str, auth: None = Depends(verify_auth)):
     try:
         datetime.strptime(date, "%Y-%m-%d")
     except ValueError:


### PR DESCRIPTION
## Summary
- add support for HTTP Basic and API key auth via `.env`
- calculate Beaufort scale and include in weather data
- model tide/weather responses for OpenAPI docs
- add `/tide-heights` endpoint with weekly refresh
- document new auth values and endpoint in README

## Testing
- `python -m pip install -r requirements.txt`
- `python -m pip install black`
- `black mcp_api.py`
- `python - <<'PY'
from mcp_api import app
spec = app.openapi()
print('paths', spec['paths'].keys())
print('tide-heights schema present:', 'TideHeight' in spec['components']['schemas'])
print('weather schema present:', 'WeatherDay' in spec['components']['schemas'])
PY`

------
https://chatgpt.com/codex/tasks/task_b_6878d7aa2b688323a1752013f80b83f9