### PR TITLE
Switch gate time logic to tide height prediction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ OPENWEATHER_KEY=your_openweather_api_key
 BASIC_AUTH_USER=your_username
 BASIC_AUTH_PASS=your_password
 MCP_API_KEY=your_api_key
+GATE_OPEN_HEIGHT=4

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Conwy Gate Times utilities.
 ## Gate time extraction
 
 `extract_gate_times.py` parses `GateTimes2025.pdf` and writes `gate_times.csv`
-using OCR.  The CSV is used by the API below.
+using OCR.  This script is retained for reference but the API now predicts gate
+times from tide height data.
 
 ```
 pip install -r requirements.txt
@@ -14,9 +15,9 @@ python extract_gate_times.py
 
 ## MCP API
 
-`mcp_api.py` implements a small FastAPI service providing:
+- `mcp_api.py` implements a small FastAPI service providing:
 
-- `/tides` and `/tides/{YYYY-MM-DD}` - 12\u00a0months of cached tide data from
+- `/tides/{YYYY-MM-DD}` - 12\u00a0months of cached tide data from
   [WorldTides](https://www.worldtides.info/apidocs) converted to local time.
 - `/tide-heights` - half hour tide heights for the next 7 days refreshed once a
   week. Heights are relative to chart datum (CD).
@@ -29,8 +30,10 @@ python extract_gate_times.py
   [Farmsense](https://api.farmsense.net/v1/moonphases/).
 - `/marine` - sea level and ocean current forecast from
   [Open-Meteo](https://open-meteo.com/).
-- `/gate-times` and `/gate-times/{YYYY-MM-DD}` - gate raise and lower times
-  extracted from `GateTimes2025.pdf`.
+- `/gate-times` and `/gate-times/{YYYY-MM-DD}` - predicted gate raise and lower
+  times calculated from tide height forecasts. The gate opens when the tide
+  rises to `GATE_OPEN_HEIGHT` metres (default 4&nbsp;m) and closes when it falls
+  back below this level.
 
 
 Tide, weather and gate time data are cached in memory and refreshed every
@@ -40,7 +43,8 @@ format for Conwy, North Wales.
 
 Copy `.env.example` to `.env` and fill in your `WORLDTIDES_KEY`,
 `OPENWEATHER_KEY`, and authentication values `BASIC_AUTH_USER`,
-`BASIC_AUTH_PASS` or `MCP_API_KEY`.
+`BASIC_AUTH_PASS` or `MCP_API_KEY`. You can also adjust
+`GATE_OPEN_HEIGHT` to change the tide height used for gate predictions.
 
 All API endpoints require authentication using either HTTP Basic credentials or
 an `X-API-KEY` header containing the value of `MCP_API_KEY`.


### PR DESCRIPTION
## Summary
- predict gate times from `/tide-heights` instead of CSV
- simplify tide caches and fix `/tides/{date}` lookup
- remove `/tides` endpoint
- document new behaviour in README
- gate open height configurable with `GATE_OPEN_HEIGHT` (default 4m)

## Testing
- `python -m py_compile mcp_api.py`


------
https://chatgpt.com/codex/tasks/task_b_6880ee1646b48323b081a0dca8e1e2bc