### PR TITLE
Fix gate action names and add tide height

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ python extract_gate_times.py
 - `/marine` - sea level and ocean current forecast from
   [Open-Meteo](https://open-meteo.com/).
 - `/gate-times` and `/gate-times/{YYYY-MM-DD}` - predicted gate raise and lower
-  times calculated from tide height forecasts. The gate opens when the tide
-  rises to `GATE_OPEN_HEIGHT` metres (default 4&nbsp;m) and closes when it falls
-  back below this level.
+  times calculated from tide height forecasts. Each event includes the date and
+  time, the action to take and the tide height. The gate is **lowered** as the
+  tide rises to `GATE_OPEN_HEIGHT` metres (default 4&nbsp;m) and **raised** once
+  it falls back below this level.
 
 
 Tide, weather and gate time data are cached in memory and refreshed every

--- a/mcp_api.py
+++ b/mcp_api.py
@@ -287,7 +287,13 @@ def load_weather_data():
 
 
 def calculate_gate_times():
-    """Calculate approximate gate raise/lower times from tide heights."""
+    """Calculate approximate gate raise/lower times from tide heights.
+
+    The terms "raise" and "lower" in the returned events correspond to the
+    physical movement of the gate in Conwy. The gate is **lowered** when the
+    tide rises above ``GATE_OPEN_HEIGHT`` and **raised** again once it falls
+    back below this level.
+    """
     if not app.state.tide_heights_cache:
         load_tide_heights()
 
@@ -305,13 +311,21 @@ def calculate_gate_times():
                 ratio = (threshold - prev_height) / (height - prev_height)
                 crossing = prev_dt + (dt - prev_dt) * ratio
                 date_key = crossing.strftime("%Y-%m-%d")
-                event = {"datetime": crossing.isoformat(), "action": "raise"}
+                event = {
+                    "datetime": crossing.isoformat(),
+                    "action": "lower",
+                    "height": threshold,
+                }
                 events.setdefault(date_key, []).append(event)
             elif prev_height > threshold >= height:
                 ratio = (prev_height - threshold) / (prev_height - height)
                 crossing = prev_dt + (dt - prev_dt) * ratio
                 date_key = crossing.strftime("%Y-%m-%d")
-                event = {"datetime": crossing.isoformat(), "action": "lower"}
+                event = {
+                    "datetime": crossing.isoformat(),
+                    "action": "raise",
+                    "height": threshold,
+                }
                 events.setdefault(date_key, []).append(event)
 
         prev_dt = dt


### PR DESCRIPTION
## Summary
- fix gate action labels (raise/lower were reversed)
- include tide height in gate-time events
- document new behaviour in README

## Testing
- `python -m py_compile mcp_api.py extract_gate_times.py`


------
https://chatgpt.com/codex/tasks/task_b_6880f3858978832381cb5a7f536df71e