### PR TITLE
Update tide height cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ python extract_gate_times.py
 
 - `/tides/{YYYY-MM-DD}` - 12\u00a0months of cached tide data from
   [WorldTides](https://www.worldtides.info/apidocs) converted to local time.
-- `/tide-heights` - half hour tide heights for the next 7 days refreshed once a
-  week. Heights are relative to chart datum (CD).
+- `/tide-heights` - half hour tide heights for the next 6 months refreshed once
+  a week. Heights are relative to chart datum (CD).
 - `/weather/{YYYY-MM-DD}` - weather forecast for a day if it is within the next
   five days using [OpenWeather](https://openweathermap.org/api/one-call-3), also
   returned in local time.


### PR DESCRIPTION
## Summary
- fetch 6 months of tide heights
- refresh tide heights weekly or when cache is empty
- document new 6‑month tide height behaviour

## Testing
- `python -m py_compile mcp_api.py`
- `python -m py_compile extract_gate_times.py`

------
https://chatgpt.com/codex/tasks/task_b_6880f83ede988323988c4db4f221aa11